### PR TITLE
Disallow raise when call uses entire stack

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -67,9 +67,9 @@ jobs:
           sccache: 'true'
           manylinux: auto
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-linux-${{ matrix.target }}
           path: dist
       
 
@@ -107,9 +107,9 @@ jobs:
           args: --release --out dist --find-interpreter
           sccache: 'true'
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-windows-${{ matrix.target }}
           path: dist
 
   macos:
@@ -146,9 +146,9 @@ jobs:
           args: --release --out dist --find-interpreter
           sccache: 'true'
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-macos-${{ matrix.target }}
           path: dist
 
   sdist:
@@ -162,9 +162,9 @@ jobs:
           command: sdist
           args: --out dist
       - name: Upload sdist
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: sdist
           path: dist
 
   release:
@@ -173,13 +173,14 @@ jobs:
     if: "startsWith(github.ref, 'refs/tags/v')"
     needs: [rust_tests, linux, windows, macos, sdist]
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: wheels
+          path: dist
+          merge-multiple: true
       - name: Publish to PyPI
         uses: PyO3/maturin-action@v1
         env:
           MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         with:
           command: upload
-          args: --skip-existing *
+          args: --skip-existing dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pokers"
+dynamic = ["version"]
 description = "Embarrassingly simple No Limit Texas Holdem environment for RL"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/src/game_logic.rs
+++ b/src/game_logic.rs
@@ -19,6 +19,8 @@ macro_rules! verbose_println {
     };
 }
 
+const CHIP_EPSILON: f64 = 1e-9;
+
 pub struct InitStateError {
     msg: String,
 }
@@ -359,10 +361,22 @@ fn legal_actions(state: &State) -> Vec<ActionEnum> {
         illegal_actions.push(ActionEnum::Check);
     }
 
+    if !current_player_can_raise(state) {
+        illegal_actions.push(ActionEnum::Raise);
+    }
+
     let legal_actions: Vec<ActionEnum> = ActionEnum::iter()
         .filter(|a| !illegal_actions.contains(a))
         .collect();
     legal_actions
+}
+
+fn current_player_can_raise(state: &State) -> bool {
+    let player_state = state.players_state[state.current_player as usize];
+    let call_amount = f64::max(0.0, state.min_bet - player_state.bet_chips);
+    let remaining_stake_after_call = player_state.stake - call_amount;
+
+    remaining_stake_after_call > CHIP_EPSILON
 }
 
 // Modified to accept state parameter for verbose control

--- a/tests/test_game_logic.py
+++ b/tests/test_game_logic.py
@@ -92,3 +92,19 @@ def test_illegal_actions():
 
     high_bet_state = state.apply_action(pkrs.Action(pkrs.ActionEnum.Raise, amount=101))
     assert high_bet_state.status == pkrs.StateStatus.HighBet
+
+
+def test_raise_is_not_legal_when_call_uses_entire_stack():
+    state = pkrs.State.from_seed(
+        n_players=3, button=0, sb=1.0, bb=2.0, stake=4.0, seed=0
+    )
+
+    state = state.apply_action(pkrs.Action(pkrs.ActionEnum.Raise, amount=2.0))
+    state = state.apply_action(pkrs.Action(pkrs.ActionEnum.Call))
+
+    current_player = state.players_state[state.current_player]
+    call_amount = state.min_bet - current_player.bet_chips
+
+    assert call_amount == current_player.stake
+    assert pkrs.ActionEnum.Call in state.legal_actions
+    assert pkrs.ActionEnum.Raise not in state.legal_actions


### PR DESCRIPTION
## Summary

This PR fixes an invalid `legal_actions` case in all-in / near-all-in states.

The bug appears when the acting player has exactly enough chips left to call but not enough to raise further. In that state, `pokers` could still expose:

- `Fold`
- `Call`
- `Raise`

That is incorrect for this library's action model, because `Raise(amount)` represents the additional raise increment beyond the call amount. If calling consumes the player's full remaining stack, there is no valid raise increment left, so `Raise` should not be legal.

This was causing downstream clients to generate invalid all-in raise actions and hit `StateStatus.HighBet`.

## Root Cause

`legal_actions()` only looked at generic street/bet conditions and did not check whether the current player had any chips left after matching `min_bet`.

As a result, a player with:

- `stake == call_amount`

could still be offered `Raise`, even though any raise increment would necessarily be invalid.

## Changes

Updated [src/game_logic.rs](/Users/dberweger/Local/pokers/src/game_logic.rs):

- added `current_player_can_raise(state)`
- `legal_actions()` now removes `ActionEnum::Raise` when:
  - the player cannot put in any chips beyond the call amount

In practice:
- if the player can still add chips after calling, `Raise` remains legal
- if calling uses the entire stack, only `Fold` / `Call` remain legal

## Tests

Added coverage in [tests/test_game_logic.py](/Users/dberweger/Local/pokers/tests/test_game_logic.py):

- `test_raise_is_not_legal_when_call_uses_entire_stack`

This reproduces a concrete state where:
- player 0 raises
- player 1 calls
- player 2 is left with exactly enough chips to call

Expected result:
- `Call` is legal
- `Raise` is not legal

## Validation

Ran:

```bash
python3 -m pytest tests/test_game_logic.py -q
